### PR TITLE
changed the tpch_2_16_0.zip url to s3

### DIFF
--- a/tpch-gen/Makefile
+++ b/tpch-gen/Makefile
@@ -10,7 +10,8 @@ target/tpch_kit.zip: tpch_kit.zip
 	cp tpch_kit.zip target/tpch_kit.zip
 
 tpch_kit.zip:
-	curl --output tpch_kit.zip http://www.tpc.org/tpch/spec/tpch_2_16_0.zip
+	curl http://dev.hortonworks.com.s3.amazonaws.com/hive-testbench/tpch/README
+	curl --output tpch_kit.zip http://dev.hortonworks.com.s3.amazonaws.com/hive-testbench/tpch/tpch_kit.zip
 
 target/lib/dbgen.jar: target/tools/dbgen
 	cd target/; mkdir -p lib/; ( jar cvf lib/dbgen.jar tools/ || gjar cvf lib/dbgen.jar tools/ )


### PR DESCRIPTION
The tpch_2_16_0.zip url is no longer valid. The same zip has been uploaded to S3 and updated the url.