### PR TITLE
Fix Spark TPC-DS query 30

### DIFF
--- a/spark-queries-tpcds/q30.sql
+++ b/spark-queries-tpcds/q30.sql
@@ -20,7 +20,7 @@ SELECT
   c_birth_country,
   c_login,
   c_email_address,
-  c_last_review_date,
+  c_last_review_date_sk,
   ctr_total_return
 FROM customer_total_return ctr1, customer_address, customer
 WHERE ctr1.ctr_total_return > (SELECT avg(ctr_total_return) * 1.2
@@ -31,5 +31,5 @@ WHERE ctr1.ctr_state = ctr2.ctr_state)
   AND ctr1.ctr_customer_sk = c_customer_sk
 ORDER BY c_customer_id, c_salutation, c_first_name, c_last_name, c_preferred_cust_flag
   , c_birth_day, c_birth_month, c_birth_year, c_birth_country, c_login, c_email_address
-  , c_last_review_date, ctr_total_return
+  , c_last_review_date_sk, ctr_total_return
 LIMIT 100


### PR DESCRIPTION
The schema of table `customer` has been changed, but query 30 of Spark TPC-DS uses the old column name.