### PR TITLE
Updated download link

### DIFF
--- a/tpcds-build.sh
+++ b/tpcds-build.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 	fi
 	if [ $SKIP -ne 1 ]; then
 		echo "Maven not found, automatically installing it."
-		curl -O http://www.us.apache.org/dist/maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz 2> /dev/null
+		curl -O https://downloads.apache.org/maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz 2> /dev/null
 		if [ $? -ne 0 ]; then
 			echo "Failed to download Maven, check Internet connectivity and try again."
 			exit 1

--- a/tpch-build.sh
+++ b/tpch-build.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 	fi
 	if [ $SKIP -ne 1 ]; then
 		echo "Maven not found, automatically installing it."
-		curl -O http://www.us.apache.org/dist/maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz 2> /dev/null
+		curl -O https://downloads.apache.org/maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz 2> /dev/null
 		if [ $? -ne 0 ]; then
 			echo "Failed to download Maven, check Internet connectivity and try again."
 			exit 1


### PR DESCRIPTION
If you run the build command, you will find the a html file instead now because the link is not valid anymore.

The correct download link is included and will now download the maven binary.