### PR TITLE
Upgrade to Hive 3.1.3x and several fixes

### DIFF
--- a/sample-queries-tpcds/testbench.settings
+++ b/sample-queries-tpcds/testbench.settings
@@ -1,0 +1,2 @@
+-- avoid caching results, useful if the benchmark is run multiple times
+set hive.query.results.cache.enabled=false;

--- a/tpcds-gen/src/main/java/org/notmysock/tpcds/GenTable.java
+++ b/tpcds-gen/src/main/java/org/notmysock/tpcds/GenTable.java
@@ -75,7 +75,6 @@ public class GenTable extends Configured implements Tool {
                     dsuri.getPort(),dsuri.getPath(), 
                     dsuri.getQuery(),"dsdgen");
         Configuration conf = getConf();
-        conf.setInt("mapred.task.timeout",0);
         conf.setInt("mapreduce.task.timeout",0);
         conf.setBoolean("mapreduce.map.output.compress", true);
         conf.set("mapreduce.map.output.compress.codec", "org.apache.hadoop.io.compress.GzipCodec");

--- a/tpcds-setup.sh
+++ b/tpcds-setup.sh
@@ -124,4 +124,7 @@ make -j 1 -f $LOAD_FILE
 echo "Loading constraints"
 runcommand "$HIVE -f ddl-tpcds/bin_partitioned/add_constraints.sql --hivevar DB=${DATABASE}"
 
+echo "Computing statistics"
+runcommand "$HIVE -f ddl-tpch/bin_partitioned/analyze.sql --hivevar DB=${DATABASE}"
+
 echo "Data loaded into database ${DATABASE}."

--- a/tpch-gen/src/main/java/org/notmysock/tpch/GenTable.java
+++ b/tpch-gen/src/main/java/org/notmysock/tpch/GenTable.java
@@ -104,7 +104,6 @@ public class GenTable extends Configured implements Tool {
                     dsuri.getPort(),dsuri.getPath(), 
                     dsuri.getQuery(),"dbgen");
         Configuration conf = getConf();
-        conf.setInt("mapred.task.timeout",0);
         conf.setInt("mapreduce.task.timeout",0);
         DistributedCache.addCacheArchive(link, conf);
         Job job = new Job(conf, "GenTable+"+table+"_"+scale);


### PR DESCRIPTION
- Removed deprecated property 'mapred.task.timeout' for data generation step
- Added properties files for tcpds which was referenced but missing
- Upgraded the regex to read runtime and number of rows affected to support Hive 3.1.3 format
- Invoking script for computing statistics for tcpds, existing but not called